### PR TITLE
Fix minecraft_java probes

### DIFF
--- a/schema/minecraft_java.yaml
+++ b/schema/minecraft_java.yaml
@@ -56,10 +56,7 @@ probes:
     periodSeconds: 5
     failureThreshold: 20
     successThreshold: 3
-    timeoutSeconds: 1
   livenessProbe:
     initialDelaySeconds: 30
     periodSeconds: 5
     failureThreshold: 20
-    successThreshold: 3
-    timeoutSeconds: 1

--- a/schema_test.go
+++ b/schema_test.go
@@ -92,14 +92,11 @@ var exampleSchema Schema = Schema{
 			PeriodSeconds:       5,
 			FailureThreshold:    20,
 			SuccessThreshold:    3,
-			TimeoutSeconds:      1,
 		},
 		LivenessProbe: Probe{
 			InitialDelaySeconds: 30,
 			PeriodSeconds:       5,
 			FailureThreshold:    20,
-			SuccessThreshold:    3,
-			TimeoutSeconds:      1,
 		},
 	},
 }


### PR DESCRIPTION
The probes in the `minecraft_java` schema were incorrectly configured and could not be deployed.